### PR TITLE
Refactor coin flip UI to use env-based art and Polish defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,8 @@
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
+# Coin artwork
+NEXT_PUBLIC_COIN_HEADS_URL=
+NEXT_PUBLIC_COIN_TAILS_URL=
+
 # Remember to set the same keys on Vercel under Project -> Settings -> Environment Variables.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Next.js 15 (App Router) app for running a classroom coin toss experiment backed 
 ## Local Development
 
 1. Install dependencies: `npm install`
-2. Copy environment variables: `cp .env.example .env.local` and fill in `NEXT_PUBLIC_SUPABASE_URL` + `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+2. Copy environment variables: `cp .env.example .env.local` and fill in `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`,
+   `NEXT_PUBLIC_COIN_HEADS_URL`, and `NEXT_PUBLIC_COIN_TAILS_URL`
 3. Apply SQL in `supabase/sql/schema.sql` and `supabase/sql/policies.sql` to your Supabase project (via the SQL editor)
 4. Start the dev server: `npm run dev`
 
@@ -28,6 +29,8 @@ Linting, type checking, and build commands:
 2. In **Project -> Settings -> Environment Variables**, add:
    - `NEXT_PUBLIC_SUPABASE_URL`
    - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - `NEXT_PUBLIC_COIN_HEADS_URL`
+   - `NEXT_PUBLIC_COIN_TAILS_URL`
 3. Trigger a redeploy; Vercel will run `npm run build:ci`
 4. The `/host` page uses live Realtime subscriptions, so keep the project on a hobby/pro plan that allows them
 
@@ -41,4 +44,6 @@ Linting, type checking, and build commands:
 ## Feature Notes
 
 - `/host` shows a normalized histogram with the expected Binomial(20, 0.5) overlay, CSV export, real-time updates, and an EN/PL toggle that also adds `?lang=pl` to the QR code link.
-- `/join` blocks duplicate submissions per browser (localStorage), greets first-time visitors with an English/Polish chooser, and uses a flipping coin button rendered from `/public/coin/heads-pl.svg` + `/public/coin/tails-pl.svg`.
+- `/join` blocks duplicate submissions per browser (localStorage), greets first-time visitors with an English/Polish chooser, and
+  renders the flipping coin from URLs provided in `NEXT_PUBLIC_COIN_HEADS_URL` / `NEXT_PUBLIC_COIN_TAILS_URL` with circular
+  clipping and a rim for dark-mode support.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,13 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --coin-button-bg: #ffffff;
+  --coin-button-border: #d1d5db;
+  --coin-face-bg: #f8fafc;
+  --coin-face-highlight: rgba(255, 255, 255, 0.9);
+  --coin-face-rim: rgba(15, 23, 42, 0.12);
+  --font-geist-sans: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --font-geist-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
 }
 
 @theme inline {
@@ -16,21 +23,28 @@
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --coin-button-bg: #111827;
+    --coin-button-border: rgba(148, 163, 184, 0.35);
+    --coin-face-bg: #1f2937;
+    --coin-face-highlight: rgba(255, 255, 255, 0.08);
+    --coin-face-rim: rgba(148, 163, 184, 0.35);
+    --font-geist-sans: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    --font-geist-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
   }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans);
 }
 
 .coin-button {
   width: 12rem;
   height: 12rem;
   border-radius: 9999px;
-  border: 1px solid #d1d5db;
-  background-color: #ffffff;
+  border: 1px solid var(--coin-button-border);
+  background-color: var(--coin-button-bg);
   box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.35);
   display: flex;
   align-items: center;
@@ -57,9 +71,27 @@ body {
 }
 
 .coin-face {
-  width: 100%;
-  height: 100%;
+  width: 10rem;
+  height: 10rem;
   border-radius: 9999px;
-  object-fit: cover;
+  clip-path: circle(49% at 50% 50%);
+  overflow: hidden;
+  background-color: var(--coin-face-bg);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  box-shadow:
+    inset 0 0 0 3px var(--coin-face-highlight),
+    inset 0 0 0 8px var(--coin-face-rim);
   pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.coin-face-letter {
+  font-size: 3rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--foreground);
 }

--- a/src/app/host/page.tsx
+++ b/src/app/host/page.tsx
@@ -94,7 +94,7 @@ export default function HostPage() {
     return () => {
       ignore = true;
     };
-  }, [session?.id]);
+  }, [session?.id, t]);
 
   useEffect(() => {
     const sessionId = session?.id;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { I18nProvider } from "@/lib/i18n";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Coin Toss",
@@ -24,10 +13,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+    <html lang="pl">
+      <body className="antialiased">
         <I18nProvider>{children}</I18nProvider>
       </body>
     </html>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -191,7 +191,7 @@ type I18nContextValue = {
 const I18nContext = createContext<I18nContextValue | undefined>(undefined);
 
 export function I18nProvider({ children }: { children: ReactNode }) {
-  const [lang, setLangState] = useState<Lang>('en');
+  const [lang, setLangState] = useState<Lang>('pl');
 
   useEffect(() => {
     if (typeof window === 'undefined') {

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,13 +1,22 @@
 import { createClient } from "@supabase/supabase-js";
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+const fallbackUrl = "http://localhost:54321";
+const fallbackAnonKey = "public-anon-key";
+
+if (!url || !anon) {
+  console.warn(
+    "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY. Using a placeholder Supabase client; set real values in your environment."
+  );
+}
 
 /**
  * Pojedynczy klient Supabase dla całej aplikacji (public schema).
  * Wymaga poprawnie ustawionych zmiennych w .env.local
  */
-export const supabase = createClient(url, anon, {
+export const supabase = createClient(url ?? fallbackUrl, anon ?? fallbackAnonKey, {
   db: { schema: "public" },
   realtime: { params: { eventsPerSecond: 5 } },
 });


### PR DESCRIPTION
## Summary
- load coin artwork from NEXT_PUBLIC_COIN_HEADS_URL / NEXT_PUBLIC_COIN_TAILS_URL and render it inside a circular rimmed button with dark-mode-friendly styling and Polish O/R grid symbols
- default the interface to Polish, keep the language picker, and improve dark theme contrast across the join flow while setting the html lang to pl
- document the new environment variables, add fallbacks for missing Supabase envs, and avoid Google font downloads during CI builds

## Testing
- npm run build:ci

------
https://chatgpt.com/codex/tasks/task_e_68d0cd59d574832cbd255408d13cda7e