### PR TITLE
Add host sessions manager and polish coin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,20 @@ Linting, type checking, and build commands:
 
 ## Feature Notes
 
-- `/host` shows a normalized histogram with the expected Binomial(20, 0.5) overlay, CSV export, real-time updates, and an EN/PL toggle that also adds `?lang=pl` to the QR code link.
-- `/join` blocks duplicate submissions per browser (localStorage), greets first-time visitors with an English/Polish chooser, and
-  renders the flipping coin from URLs provided in `NEXT_PUBLIC_COIN_HEADS_URL` / `NEXT_PUBLIC_COIN_TAILS_URL` with circular
-  clipping and a rim for dark-mode support.
+- `/host` now includes a Sessions panel that lists the latest 20 sessions, allows resuming or closing any entry, and keeps the current session id in the URL (`/host?session=<uuid>`) as well as `localStorage` for automatic restores after refreshes. The histogram, realtime feed, and CSV export stay bound to the active session.
+- `/join` blocks duplicate submissions per browser (localStorage), greets first-time visitors with an English/Polish chooser, and renders a circular coin button that flips on tap using the artwork provided via the `NEXT_PUBLIC_COIN_HEADS_URL` / `NEXT_PUBLIC_COIN_TAILS_URL` environment variables (with inline SVG fallbacks).
+
+## Managing sessions on /host
+
+- Use the **Sessions** panel to resume any recent session or close one without leaving the dashboard. Closing is confirmed before persisting the change in Supabase.
+- Opening or resuming a session updates `localStorage['lastSessionId']` and deep-links the page to `/host?session=<uuid>` so that refreshes (or sharing the link) restore the same context.
+- The current session badge under the header exposes a quick copy button for the session id; realtime subscriptions automatically rebind when the session changes.
+
+## Localization defaults
+
+- The interface defaults to Polish (`pl`). Switch to English either with the header toggle or by appending `?lang=en` to `/host` or `/join`. Once chosen, the preference is stored in `localStorage` and reused.
+
+## Coin artwork & hosting tips
+
+- Provide high-resolution heads/tails images via `NEXT_PUBLIC_COIN_HEADS_URL` and `NEXT_PUBLIC_COIN_TAILS_URL`. If the variables are missing, the UI renders lightweight inline SVG coins instead.
+- Supabase Storage public buckets work well for hosting the coin art—upload both sides, copy their public URLs, and set the variables locally (`.env.local`) and in Vercel (Project → Settings → Environment Variables).

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,11 +3,11 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
-  --coin-button-bg: #ffffff;
-  --coin-button-border: #d1d5db;
-  --coin-face-bg: #f8fafc;
-  --coin-face-highlight: rgba(255, 255, 255, 0.9);
-  --coin-face-rim: rgba(15, 23, 42, 0.12);
+  --coin-button-bg: #f8fafc;
+  --coin-button-border: rgba(15, 23, 42, 0.12);
+  --coin-face-bg: #f4f4f5;
+  --coin-face-highlight: rgba(255, 255, 255, 0.7);
+  --coin-face-rim: rgba(15, 23, 42, 0.22);
   --font-geist-sans: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --font-geist-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
 }
@@ -24,10 +24,10 @@
     --background: #0a0a0a;
     --foreground: #ededed;
     --coin-button-bg: #111827;
-    --coin-button-border: rgba(148, 163, 184, 0.35);
-    --coin-face-bg: #1f2937;
-    --coin-face-highlight: rgba(255, 255, 255, 0.08);
-    --coin-face-rim: rgba(148, 163, 184, 0.35);
+    --coin-button-border: rgba(148, 163, 184, 0.45);
+    --coin-face-bg: #1c1f27;
+    --coin-face-highlight: rgba(255, 255, 255, 0.16);
+    --coin-face-rim: rgba(148, 163, 184, 0.45);
     --font-geist-sans: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     --font-geist-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
   }
@@ -43,9 +43,9 @@ body {
   width: 12rem;
   height: 12rem;
   border-radius: 9999px;
-  border: 1px solid var(--coin-button-border);
+  border: 2px solid var(--coin-button-border);
   background-color: var(--coin-button-bg);
-  box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 22px 55px -22px rgba(15, 23, 42, 0.45);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -54,7 +54,7 @@ body {
 }
 
 .coin-button:hover:not(.coin-button-disabled) {
-  box-shadow: 0 24px 50px -18px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 30px 65px -28px rgba(15, 23, 42, 0.5);
 }
 
 .coin-button:active:not(.coin-button-disabled) {
@@ -71,27 +71,41 @@ body {
 }
 
 .coin-face {
+  position: relative;
   width: 10rem;
   height: 10rem;
   border-radius: 9999px;
-  clip-path: circle(49% at 50% 50%);
   overflow: hidden;
   background-color: var(--coin-face-bg);
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  box-shadow:
-    inset 0 0 0 3px var(--coin-face-highlight),
-    inset 0 0 0 8px var(--coin-face-rim);
+  box-shadow: inset 0 0 35px rgba(15, 23, 42, 0.12);
   pointer-events: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
-.coin-face-letter {
-  font-size: 3rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  color: var(--foreground);
+.coin-face::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow:
+    inset 0 0 0 3px var(--coin-face-highlight),
+    inset 0 0 0 9px var(--coin-face-rim);
+  pointer-events: none;
+}
+
+.coin-face::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 35% 25%, rgba(255, 255, 255, 0.28), transparent 58%),
+    linear-gradient(140deg, rgba(255, 255, 255, 0.15), transparent 60%);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.coin-face-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
 }

--- a/src/app/host/page.tsx
+++ b/src/app/host/page.tsx
@@ -28,6 +28,7 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend,
 const Bar = NextDynamic(() => import('react-chartjs-2').then((mod) => mod.Bar), { ssr: false });
 
 const FLIP_TARGET = 20;
+const LAST_SESSION_STORAGE_KEY = 'lastSessionId';
 
 type Session = { id: string; is_open: boolean; created_at: string };
 
@@ -53,6 +54,11 @@ export default function HostPage() {
   const [realtimeReady, setRealtimeReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(false);
+  const [sessionsError, setSessionsError] = useState<string | null>(null);
+  const [resumingSessionId, setResumingSessionId] = useState<string | null>(null);
+  const [closingSessionId, setClosingSessionId] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -61,10 +67,86 @@ export default function HostPage() {
     setOrigin(window.location.origin);
   }, []);
 
+  const mergeSessionIntoState = useCallback((next: Session) => {
+    setSessions((previous) => {
+      const filtered = previous.filter((item) => item.id !== next.id);
+      const merged = [next, ...filtered];
+      merged.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+      return merged.slice(0, 20);
+    });
+    setSession((current) => {
+      if (current?.id === next.id) {
+        return next;
+      }
+      return current;
+    });
+  }, []);
+
+  const loadSessionById = useCallback(
+    async (id: string) => {
+      const { data, error: loadError } = await supabase
+        .from('sessions')
+        .select('id, created_at, is_open')
+        .eq('id', id)
+        .maybeSingle();
+
+      if (loadError || !data) {
+        return null;
+      }
+
+      const loaded = data as Session;
+      mergeSessionIntoState(loaded);
+      return loaded;
+    },
+    [mergeSessionIntoState],
+  );
+
+  const activateSession = useCallback(
+    (next: Session, options?: { replaceUrl?: boolean }) => {
+      setSession(next);
+      setResults([]);
+      setRealtimeReady(false);
+      mergeSessionIntoState(next);
+
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(LAST_SESSION_STORAGE_KEY, next.id);
+        const params = new URLSearchParams(window.location.search);
+        params.set('session', next.id);
+        params.set('lang', lang);
+        const query = params.toString();
+        const method: 'pushState' | 'replaceState' = options?.replaceUrl ? 'replaceState' : 'pushState';
+        window.history[method]({}, '', `${window.location.pathname}?${query}`);
+      }
+    },
+    [lang, mergeSessionIntoState],
+  );
+
+  const refreshSessions = useCallback(async () => {
+    setSessionsLoading(true);
+    setSessionsError(null);
+    const { data, error: listError } = await supabase
+      .from('sessions')
+      .select('id, created_at, is_open')
+      .order('created_at', { ascending: false })
+      .limit(20);
+
+    if (listError) {
+      setSessionsError(t('couldNotLoadResults'));
+      setSessionsLoading(false);
+      return null;
+    }
+
+    const list = (data ?? []) as Session[];
+    setSessions(list);
+    setSessionsLoading(false);
+    return list;
+  }, [t]);
+
   useEffect(() => {
     const sessionId = session?.id;
     if (!sessionId) {
       setRealtimeReady(false);
+      setResults([]);
       return;
     }
 
@@ -129,6 +211,63 @@ export default function HostPage() {
       setRealtimeReady(false);
     };
   }, [session?.id, t]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      void refreshSessions();
+      return;
+    }
+
+    let cancelled = false;
+
+    const bootstrap = async () => {
+      await refreshSessions();
+
+      if (cancelled) {
+        return;
+      }
+
+      const params = new URLSearchParams(window.location.search);
+      const fromUrl = params.get('session');
+      const stored = window.localStorage.getItem(LAST_SESSION_STORAGE_KEY);
+      const target = fromUrl ?? stored ?? null;
+
+      if (!target) {
+        return;
+      }
+
+      const loaded = await loadSessionById(target);
+
+      if (cancelled || !loaded) {
+        if (stored && !loaded) {
+          window.localStorage.removeItem(LAST_SESSION_STORAGE_KEY);
+        }
+        return;
+      }
+
+      activateSession(loaded, { replaceUrl: true });
+    };
+
+    void bootstrap();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activateSession, loadSessionById, refreshSessions]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    if (session?.id) {
+      params.set('session', session.id);
+    }
+    params.set('lang', lang);
+    const query = params.toString();
+    window.history.replaceState({}, '', `${window.location.pathname}?${query}`);
+  }, [lang, session?.id]);
 
   const joinUrl = useMemo(() => {
     if (!origin || !session?.id) {
@@ -289,16 +428,43 @@ export default function HostPage() {
         throw insertError;
       }
 
-      setSession(data as Session);
-      setResults([]);
-      setRealtimeReady(false);
+      activateSession(data as Session);
+      void refreshSessions();
     } catch (error) {
       console.error('Failed to open session', error);
       setError(t('couldNotOpen'));
     } finally {
       setLoadingSession(false);
     }
-  }, [t]);
+  }, [activateSession, refreshSessions, t]);
+
+  const handleCloseSessionById = useCallback(
+    async (sessionId: string, { updateLocalState = true }: { updateLocalState?: boolean } = {}) => {
+      const { data, error: updateError } = await supabase
+        .from('sessions')
+        .update({ is_open: false })
+        .eq('id', sessionId)
+        .select('id, created_at, is_open')
+        .single();
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      if (updateLocalState) {
+        mergeSessionIntoState(data as Session);
+        setSession((current) => {
+          if (current?.id === sessionId) {
+            return data as Session;
+          }
+          return current;
+        });
+      }
+
+      return data as Session;
+    },
+    [mergeSessionIntoState],
+  );
 
   const closeSession = useCallback(async () => {
     if (!session?.id) {
@@ -310,23 +476,81 @@ export default function HostPage() {
     setNotice(null);
 
     try {
-      const { data, error: updateError } = await supabase
-        .from('sessions')
-        .update({ is_open: false })
-        .eq('id', session.id)
-        .select('id, created_at, is_open')
-        .single();
-
-      if (updateError) {
-        throw updateError;
-      }
-
-      setSession(data as Session);
+      const updated = await handleCloseSessionById(session.id, { updateLocalState: false });
+      mergeSessionIntoState(updated);
+      setSession(updated);
+      void refreshSessions();
     } catch (error) {
       console.error('Failed to close session', error);
       setError(t('couldNotClose'));
     } finally {
       setClosing(false);
+    }
+  }, [handleCloseSessionById, mergeSessionIntoState, refreshSessions, session?.id, t]);
+
+  const handleResumeSession = useCallback(
+    async (sessionId: string) => {
+      setError(null);
+      setNotice(null);
+      setResumingSessionId(sessionId);
+      try {
+        const loaded = await loadSessionById(sessionId);
+        if (!loaded) {
+          setError(t('couldNotLoadResults'));
+          return;
+        }
+        activateSession(loaded);
+      } catch (resumeError) {
+        console.error('Failed to resume session', resumeError);
+        setError(t('couldNotLoadResults'));
+      } finally {
+        setResumingSessionId(null);
+      }
+    },
+    [activateSession, loadSessionById, t],
+  );
+
+  const handleCloseSessionFromList = useCallback(
+    async (sessionId: string) => {
+      if (typeof window !== 'undefined') {
+        const confirmed = window.confirm(t('confirmClose'));
+        if (!confirmed) {
+          return;
+        }
+      }
+
+      setError(null);
+      setNotice(null);
+      setClosingSessionId(sessionId);
+
+      try {
+        const updated = await handleCloseSessionById(sessionId, { updateLocalState: false });
+        mergeSessionIntoState(updated);
+        void refreshSessions();
+      } catch (closeError) {
+        console.error('Failed to close session', closeError);
+        setError(t('couldNotClose'));
+      } finally {
+        setClosingSessionId(null);
+      }
+    },
+    [handleCloseSessionById, mergeSessionIntoState, refreshSessions, t],
+  );
+
+  const handleCopySessionId = useCallback(async () => {
+    if (!session?.id) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(session.id);
+      setNotice(t('copySuccess'));
+      if (typeof window !== 'undefined') {
+        window.setTimeout(() => setNotice(null), 2000);
+      }
+    } catch (copyError) {
+      console.error('Failed to copy session id', copyError);
+      setNotice(t('copyError'));
     }
   }, [session?.id, t]);
 
@@ -335,15 +559,28 @@ export default function HostPage() {
       <div className="mx-auto max-w-6xl space-y-6">
         <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h1 className="text-2xl font-bold">{t('appTitleHost')}</h1>
-            <div className="text-sm text-gray-600">
-              {t('participants')}: <b>{participants}</b> | {t('totalFlips')}: <b>{totalFlips}</b> | {t('totalHeads')}: <b>{totalHeads}</b> |{' '}
-              {t('pvalueLabel')}: {pValue === null ? 'n/a' : <b>{pValue.toFixed(4)}</b>}
+            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{t('appTitleHost')}</h1>
+            <div className="text-sm text-zinc-600 dark:text-zinc-300">
+              {t('participants')}: <b>{participants}</b> | {t('totalFlips')}: <b>{totalFlips}</b> | {t('totalHeads')}:{' '}
+              <b>{totalHeads}</b> | {t('pvalueLabel')}: {pValue === null ? 'n/a' : <b>{pValue.toFixed(4)}</b>}
             </div>
+            {session && (
+              <div className="mt-3 inline-flex items-center gap-2 rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-200">
+                <span>{t('lastSession')}:</span>
+                <code className="font-mono text-[11px]">{session.id}</code>
+                <button
+                  type="button"
+                  onClick={handleCopySessionId}
+                  className="rounded-full border border-transparent bg-zinc-900 px-2 py-1 text-white transition hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-white/80"
+                >
+                  {t('copyId')}
+                </button>
+              </div>
+            )}
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <div
-              className="flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-medium"
+              className="flex items-center gap-1 rounded-full border border-zinc-300 bg-white px-2 py-1 text-xs font-medium text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
               role="group"
               aria-label={t('chooseLanguageLabel')}
             >
@@ -353,7 +590,9 @@ export default function HostPage() {
                   type="button"
                   onClick={() => setLang(code)}
                   className={`rounded-full px-2 py-1 transition ${
-                    lang === code ? 'bg-black text-white' : 'text-gray-600 hover:text-black'
+                    lang === code
+                      ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900'
+                      : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-white'
                   }`}
                   aria-pressed={lang === code}
                 >
@@ -365,7 +604,7 @@ export default function HostPage() {
               type="button"
               onClick={openSession}
               disabled={loadingSession || (session?.is_open ?? false)}
-              className="rounded-xl bg-black px-4 py-2 text-white disabled:opacity-50"
+              className="rounded-xl bg-zinc-900 px-4 py-2 text-white transition hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-white/80"
             >
               {loadingSession ? t('sending') : t('openSession')}
             </button>
@@ -373,7 +612,7 @@ export default function HostPage() {
               type="button"
               onClick={closeSession}
               disabled={!session?.is_open || closing}
-              className="rounded-xl border px-4 py-2 disabled:opacity-50"
+              className="rounded-xl border border-zinc-300 bg-white px-4 py-2 text-zinc-800 transition hover:border-zinc-400 disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:border-zinc-500"
             >
               {closing ? t('sending') : t('closeSession')}
             </button>
@@ -381,7 +620,7 @@ export default function HostPage() {
               type="button"
               onClick={handleExportCsv}
               disabled={!session || results.length === 0}
-              className="rounded-xl border px-4 py-2 disabled:opacity-50"
+              className="rounded-xl border border-zinc-300 bg-white px-4 py-2 text-zinc-800 transition hover:border-zinc-400 disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:border-zinc-500"
             >
               {t('exportCsv')}
             </button>
@@ -389,39 +628,101 @@ export default function HostPage() {
         </header>
 
         {error && (
-          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/50 dark:bg-red-500/10 dark:text-red-200">
             {error}
           </div>
         )}
 
         {notice && (
-          <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700">
+          <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700 dark:border-blue-500/40 dark:bg-blue-500/10 dark:text-blue-200">
             {notice}
           </div>
         )}
 
         {!session && (
-          <div className="rounded-2xl border px-6 py-12 text-center text-gray-700">
+          <div className="rounded-2xl border border-zinc-300 bg-white px-6 py-12 text-center text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-200">
             {t('openSessionPrompt')}
           </div>
         )}
 
         {session && (
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-            <section className="rounded-2xl border p-4">
+          <div className="grid grid-cols-1 gap-6 xl:grid-cols-4">
+            <section className="rounded-2xl border border-zinc-300 bg-white p-4 text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100">
+              <h2 className="mb-3 text-lg font-semibold">{t('sessionsPanel')}</h2>
+              {sessionsError && (
+                <div className="mb-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-500/50 dark:bg-red-500/10 dark:text-red-200">
+                  {sessionsError}
+                </div>
+              )}
+              {sessionsLoading ? (
+                <div className="text-sm text-zinc-600 dark:text-zinc-300">{t('waiting')}</div>
+              ) : sessions.length === 0 ? (
+                <div className="text-sm text-zinc-600 dark:text-zinc-300">{t('noSessionsYet')}</div>
+              ) : (
+                <ul className="space-y-3">
+                  {sessions.map((item) => {
+                    const createdAt = new Date(item.created_at);
+                    const isCurrent = session?.id === item.id;
+                    return (
+                      <li
+                        key={item.id}
+                        className="rounded-xl border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-700 dark:border-zinc-600 dark:bg-zinc-900/40 dark:text-zinc-200"
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="flex-1 space-y-1">
+                            <div className="font-semibold text-zinc-900 dark:text-zinc-100">
+                              {createdAt.toLocaleString()}
+                            </div>
+                            <div className="break-all font-mono text-[11px] text-zinc-600 dark:text-zinc-300">{item.id}</div>
+                            <div className="text-[11px] text-zinc-500 dark:text-zinc-400">
+                              {item.is_open ? t('statusOpen') : t('statusClosed')}
+                              {isCurrent ? (
+                                <span className="ml-2 rounded-full bg-emerald-500/20 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-200">
+                                  {t('lastSession')}
+                                </span>
+                              ) : null}
+                            </div>
+                          </div>
+                          <div className="flex flex-col gap-2">
+                            <button
+                              type="button"
+                              onClick={() => handleResumeSession(item.id)}
+                              disabled={resumingSessionId === item.id}
+                              className="rounded-lg bg-zinc-900 px-2 py-1 text-white transition hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-white/80"
+                            >
+                              {resumingSessionId === item.id ? t('sending') : t('resume')}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleCloseSessionFromList(item.id)}
+                              disabled={!item.is_open || closingSessionId === item.id}
+                              className="rounded-lg border border-zinc-300 bg-white px-2 py-1 text-zinc-700 transition hover:border-zinc-400 disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:border-zinc-500"
+                            >
+                              {closingSessionId === item.id ? t('sending') : t('close')}
+                            </button>
+                          </div>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </section>
+
+            <section className="rounded-2xl border border-zinc-300 bg-white p-4 text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 xl:col-span-1">
               <h2 className="mb-3 text-lg font-semibold">{t('joinLink')}</h2>
               <div className="mb-3">
-                <div className="mb-1 text-sm text-gray-600">{t('sessionId')}</div>
-                <code className="break-all text-sm">{session.id}</code>
+                <div className="mb-1 text-sm text-zinc-600 dark:text-zinc-300">{t('sessionId')}</div>
+                <code className="break-all text-sm text-zinc-800 dark:text-zinc-100">{session.id}</code>
               </div>
               <div className="mb-3">
-                <div className="mb-1 text-sm text-gray-600">{t('url')}</div>
+                <div className="mb-1 text-sm text-zinc-600 dark:text-zinc-300">{t('url')}</div>
                 <div className="flex items-center gap-2">
-                  <code className="break-all text-sm">{joinUrl || 'n/a'}</code>
+                  <code className="break-all text-sm text-zinc-800 dark:text-zinc-100">{joinUrl || 'n/a'}</code>
                   <button
                     type="button"
                     onClick={handleCopyLink}
-                    className="rounded-lg border px-2 py-1 text-sm disabled:opacity-50"
+                    className="rounded-lg border border-zinc-300 bg-white px-2 py-1 text-sm text-zinc-700 transition hover:border-zinc-400 disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:border-zinc-500"
                     disabled={!joinUrl}
                   >
                     {t('copy')}
@@ -432,51 +733,51 @@ export default function HostPage() {
                 {joinUrl ? (
                   <QRCodeSVG value={joinUrl} size={196} includeMargin />
                 ) : (
-                  <div className="text-sm text-gray-500">{t('qrPending')}</div>
+                  <div className="text-sm text-zinc-500 dark:text-zinc-400">{t('qrPending')}</div>
                 )}
               </div>
-              <div className="text-sm text-gray-700">
+              <div className="text-sm text-zinc-700 dark:text-zinc-200">
                 Status:{' '}
                 {session.is_open ? (
-                  <span className="text-green-700">{t('statusOpen')}</span>
+                  <span className="text-green-700 dark:text-emerald-300">{t('statusOpen')}</span>
                 ) : (
-                  <span className="text-gray-600">{t('statusClosed')}</span>
+                  <span className="text-zinc-500 dark:text-zinc-400">{t('statusClosed')}</span>
                 )}
                 {realtimeReady ? (
-                  <span className="ml-2 text-xs text-gray-500">{t('realtimeOn')}</span>
+                  <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-300">{t('realtimeOn')}</span>
                 ) : (
-                  <span className="ml-2 text-xs text-gray-400">{t('realtimeLoading')}</span>
+                  <span className="ml-2 text-xs text-zinc-400 dark:text-zinc-500">{t('realtimeLoading')}</span>
                 )}
               </div>
             </section>
 
-            <section className="rounded-2xl border p-4 lg:col-span-2">
+            <section className="rounded-2xl border border-zinc-300 bg-white p-4 text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 xl:col-span-2">
               <h2 className="mb-3 text-lg font-semibold">{t('liveHistogram')}</h2>
               <div className="h-72">
                 <Bar data={chartData as ChartData<'bar', number[], string>} options={chartOptions} />
               </div>
-              <div className="mt-3 text-sm text-gray-700">
+              <div className="mt-3 text-sm text-zinc-700 dark:text-zinc-200">
                 {t('pvalueLabel')}: {pValue === null ? 'n/a' : <b>{pValue.toFixed(4)}</b>}
               </div>
             </section>
 
-            <section className="rounded-2xl border p-4 lg:col-span-3">
+            <section className="rounded-2xl border border-zinc-300 bg-white p-4 text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 xl:col-span-4">
               <h2 className="mb-3 text-lg font-semibold">{t('latestSubmissions')}</h2>
               {results.length === 0 ? (
-                <div className="text-sm text-gray-600">{t('waitingForResults')}</div>
+                <div className="text-sm text-zinc-600 dark:text-zinc-300">{t('waitingForResults')}</div>
               ) : (
-                <ul className="divide-y">
+                <ul className="divide-y divide-zinc-200 dark:divide-zinc-700">
                   {results.slice(0, 20).map((row) => (
                     <li key={row.id} className="flex items-center justify-between py-2">
                       <div className="flex items-center gap-3">
-                        <span className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-800">
+                        <span className="rounded-full bg-zinc-100 px-2 py-1 text-xs text-zinc-800 dark:bg-zinc-700 dark:text-zinc-100">
                           {row.nickname || 'n/a'}
                         </span>
-                        <span className="text-sm text-gray-700">
-                          {row.heads}H / {row.tails}T
+                        <span className="text-sm text-zinc-700 dark:text-zinc-200">
+                          {row.heads} {t('heads')} / {row.tails} {t('tails')}
                         </span>
                       </div>
-                      <span className="text-xs text-gray-500">{new Date(row.created_at).toLocaleTimeString()}</span>
+                      <span className="text-xs text-zinc-500 dark:text-zinc-400">{new Date(row.created_at).toLocaleTimeString()}</span>
                     </li>
                   ))}
                 </ul>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -17,6 +17,13 @@ type TranslationKey =
   | 'appTitleJoin'
   | 'openSession'
   | 'closeSession'
+  | 'sessionsPanel'
+  | 'resume'
+  | 'close'
+  | 'confirmClose'
+  | 'lastSession'
+  | 'copyId'
+  | 'noSessionsYet'
   | 'exportCsv'
   | 'joinLink'
   | 'url'
@@ -37,6 +44,7 @@ type TranslationKey =
   | 'copy'
   | 'copySuccess'
   | 'copyError'
+  | 'coinCaption'
   | 'qrPending'
   | 'nickname'
   | 'nicknamePlaceholder'
@@ -65,7 +73,9 @@ type TranslationKey =
   | 'openSessionPrompt'
   | 'chooseLanguage'
   | 'languageBar'
-  | 'chooseLanguageLabel';
+  | 'chooseLanguageLabel'
+  | 'headsSymbol'
+  | 'tailsSymbol';
 
 type Dictionary = Record<TranslationKey, string>;
 
@@ -75,6 +85,13 @@ const dictionaries: Record<Lang, Dictionary> = {
     appTitleJoin: 'Coin Toss · Join',
     openSession: 'Open session',
     closeSession: 'Close session',
+    sessionsPanel: 'Sessions',
+    resume: 'Resume',
+    close: 'Close',
+    confirmClose: 'Are you sure you want to close this session?',
+    lastSession: 'Current session',
+    copyId: 'Copy ID',
+    noSessionsYet: 'No sessions yet.',
     exportCsv: 'Export CSV',
     joinLink: 'Join link',
     url: 'URL',
@@ -95,6 +112,7 @@ const dictionaries: Record<Lang, Dictionary> = {
     copy: 'Copy',
     copySuccess: 'Link copied to clipboard.',
     copyError: 'Could not copy the link. Copy it manually.',
+    coinCaption: 'Heads / Tails',
     qrPending: 'QR will appear after opening a session.',
     nickname: 'Nickname',
     nicknamePlaceholder: 'Your nickname',
@@ -124,12 +142,21 @@ const dictionaries: Record<Lang, Dictionary> = {
     chooseLanguage: 'Choose language',
     languageBar: 'Choose language / Wybierz język:',
     chooseLanguageLabel: 'Language',
+    headsSymbol: 'Hd',
+    tailsSymbol: 'Tl',
   },
   pl: {
     appTitleHost: 'Rzut monetą · Prowadzący',
     appTitleJoin: 'Rzut monetą · Dołącz',
     openSession: 'Otwórz sesję',
     closeSession: 'Zamknij sesję',
+    sessionsPanel: 'Sesje',
+    resume: 'Wznów',
+    close: 'Zamknij',
+    confirmClose: 'Czy na pewno chcesz zamknąć tę sesję?',
+    lastSession: 'Aktywna sesja',
+    copyId: 'Kopiuj ID',
+    noSessionsYet: 'Brak sesji.',
     exportCsv: 'Eksportuj CSV',
     joinLink: 'Link dołączenia',
     url: 'Adres URL',
@@ -150,6 +177,7 @@ const dictionaries: Record<Lang, Dictionary> = {
     copy: 'Kopiuj',
     copySuccess: 'Skopiowano link do schowka.',
     copyError: 'Nie udało się skopiować linku. Skopiuj go ręcznie.',
+    coinCaption: 'Orzeł / Reszka',
     qrPending: 'QR pojawi się po otwarciu sesji.',
     nickname: 'Pseudonim',
     nicknamePlaceholder: 'Twój pseudonim',
@@ -179,6 +207,8 @@ const dictionaries: Record<Lang, Dictionary> = {
     chooseLanguage: 'Wybierz język',
     languageBar: 'Choose language / Wybierz język:',
     chooseLanguageLabel: 'Język',
+    headsSymbol: 'O',
+    tailsSymbol: 'R',
   },
 };
 


### PR DESCRIPTION
## Summary
- add a Sessions panel to /host with resume/close actions, session deep-linking, and automatic realtime rebinding
- refresh the /join coin UI with configurable heads/tails imagery, inline SVG fallbacks, Polish O/R symbols, and dark-mode styling tweaks
- extend i18n keys and documentation to cover the sessions workflow, Polish-by-default language toggle, and coin hosting guidance

## Testing
- `CI=1 npm run build:ci`

## How to test
- Open `/host`, use the Sessions panel to resume/close recent sessions, and confirm the URL/localStorage updates while realtime results continue to stream
- Visit `/join` with and without the coin image env vars set, flip the coin, and verify the PL UI shows “Orzeł/Reszka” captions with the 20-slot grid using `O/R`


------
https://chatgpt.com/codex/tasks/task_e_68d0d3da15d4832c9c4b579cd1a3d2c1